### PR TITLE
Add support for `npm start`

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,5 +22,9 @@
   },
   "engines": {
     "node": "0.10.x"
+  },
+  "scripts": {
+    "start": "bin/hubot -a slack",
+    "test": "echo \"Error: no test specified\"; exit 1"
   }
 }


### PR DESCRIPTION
Allows ALICE Hubot to be run within the upstream `node` Docker container.
